### PR TITLE
fix(dash): do not send content on a 204 response

### DIFF
--- a/src/webserver/public/js/manage.js
+++ b/src/webserver/public/js/manage.js
@@ -15,7 +15,10 @@ async function getGuildConfig(id) {
     headers: {
       "CSRF-Token": token,
     },
-  }).then(res => res.json().catch(() => {}));
+  }).then(res => {
+      if (res.status === 204) return {};
+      return res.json().catch(() => {});
+  });
   return body;
 }
 
@@ -263,7 +266,7 @@ window.addEventListener("load", async () => {
     oldcfg = { ...guildConfig };
     // Updates config
     updateGuildConfig(id, guildConfig).then(res => {
-      if (res.status === 200) {
+      if (res.status === 200 || res.status === 204) {
         // Button animation & changes
         button.classList.remove("is-loading");
         button.classList.add("is-success");

--- a/src/webserver/public/js/profile.js
+++ b/src/webserver/public/js/profile.js
@@ -16,7 +16,10 @@ async function getProfileConfig(id) {
     headers: {
       "CSRF-Token": token,
     },
-  }).then(res => res.json().catch(() => {}));
+  }).then(res => {
+      if (res.status === 204) return {};
+      return res.json().catch(() => {});
+  });
   return body;
 }
 
@@ -151,7 +154,7 @@ window.addEventListener("load", async () => {
     oldcfg = { ...profileConfig };
     // Updates config
     updateProfileConfig(id, profileConfig).then(res => {
-      if (res.status === 200) {
+      if (res.status === 200 || res.status === 204) {
         // Button animation & changes
         button.classList.remove("is-loading");
         button.classList.add("is-success");

--- a/src/webserver/routes/api.js
+++ b/src/webserver/routes/api.js
@@ -63,7 +63,7 @@ module.exports = bot => {
 
     // Gets the config
     const guildConfig = await bot.db.table("guildconfig").get(guild.id).run();
-    if (!guildConfig) return res.status(204).send({ message: "Guild has empty config" });
+    if (!guildConfig) return res.status(204).end();
     res.send(guildConfig);
   });
 
@@ -85,7 +85,7 @@ module.exports = bot => {
     }
 
     // If no guildConfig
-    if (!req.body) return res.status(204).send({ message: "An empty body was sent" });
+    if (!req.body) return res.status(204).end();
     guildConfig = req.body;
 
     // Each guildConfig type/option
@@ -181,7 +181,7 @@ module.exports = bot => {
 
     // Gets the config
     const profileConfig = await bot.db.table("userconfig").get(req.user.id).run();
-    if (!profileConfig) return res.status(204).send({ message: "Profile has empty config" });
+    if (!profileConfig) return res.status(204).end();
     res.send(profileConfig);
   });
 
@@ -208,7 +208,7 @@ module.exports = bot => {
     }
 
     // If no profileConfig
-    if (!req.body) return res.status(204).send({ message: "An empty body was sent" });
+    if (!req.body) return res.status(204).end();
     profileConfig = req.body;
 
     // Each profileConfig type/option


### PR DESCRIPTION
Sending a response body with a status code of 204 No Content results in undefined behavior across browsers.

Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204#Compatibility_notes

## What does this PR do?
- [ ] Adds a feature
- [x] Fixes a bug
- [ ] Edits documentation
- [ ] Edits this repository
- [ ] Something else

## Things to check
- [ ] Have you tested changes locally?
- [x] Have you followed our linter rules?

## Notes
- [ ] New dependencies added
- [x] Unsure of functionality

## Description
@smolespi should this be a 201 Created instead?