### PR TITLE
Fixed broken Eris link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Special thanks to these people for fully translating Hibiki into other languages
 
 [source]: https://github.com/sysdotini/hibiki/blob/main/.github/CONTRIBUTING.md#source-contributions "Source contribution guidelines file."
 [donate]: https://ko-fi.com/sysdotini "Donate thru Ko-fi to help cover Hibiki's expenses."
-[eris]: https://abal.moe/eris "Eris's documentation website."
+[eris]: https://abal.moe/Eris "Eris's documentation website."
 [hibiki]: https://hibiki.app "Hibiki's official website and dashboard."
 [invite]: https://discordapp.com/oauth2/authorize?&client_id=493904957523623936&scope=bot&permissions=1581116663 "A Discord invite for the official Hibiki instance."
 [license]: LICENSE "Hibiki is licensed under the GNU AGPLv3 or later."


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds or edits a feature
- [x] Fixes a bug
- [ ] Edits typings
- [x] Edits documentation
- [ ] Edits config files
- [ ] Edits CI or workflows
- [ ] Something else

## Things to check

- [x] Have you tested changes locally?
- [x] Have you followed our linter rules? 
- [x] Have you ensured TypeScript compiles?

## Notes

- [ ] New dependencies added
- [ ] Unsure of functionality

## Description

I've edited the Eris link because the correct link is `https://abal.moe/Eris/` with a uppercase `E`, `https://abal.moe/eris/` returns a 404 Not Found error.